### PR TITLE
Now administrator permission is required to execute

### DIFF
--- a/ClickNLoadDecrypt/ClickNLoadDecrypt.csproj
+++ b/ClickNLoadDecrypt/ClickNLoadDecrypt.csproj
@@ -54,6 +54,9 @@
   <PropertyGroup>
     <StartupObject>ClickNLoadDecrypt.App</StartupObject>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Jurassic, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -117,6 +120,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <None Include="packages.config" />
+    <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/ClickNLoadDecrypt/Properties/app.manifest
+++ b/ClickNLoadDecrypt/Properties/app.manifest
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="ClickNLoadDecrypt.app"/>
+
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- Administrator required to start a HttpListener with '*' prefix -->
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+</assembly>


### PR DESCRIPTION
Fixed problem reported at [Issue #1](https://github.com/bennyborn/ClickNLoadDecrypt/issues/1)

```
this.Listener = new HttpListener();
this.Listener.Prefixes.Add("http://*:9666/");
this.Listener.Start();
```
```
System.Net.HttpListenerException: 'Access is denied'
This exception was originally thrown at this call stack:
    [External Code]
    ClickNLoadDecrypt.MainWindow.Window_Loaded(object, System.Windows.RoutedEventArgs) in MainWindow.xaml.cs
    [External Code]
```

The applied solution was to require administrator privileges to run the application.